### PR TITLE
Created users seeder with email and url_avatar

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ApplicationRecord
+ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,23 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+require 'json'
+require 'open-uri'
+
+puts "Destroying database...."
+User.destroy_all
+puts "Done!"
+
+puts "Creating database..."
+100.times do
+  url = 'https://randomuser.me/api/'
+  user_serialized = open(url).read
+  users_list = JSON.parse(user_serialized)
+
+  User.create(email: users_list["results"][0]["email"], url_avatar:
+  users_list["results"][0]["picture"]["large"], password:
+  users_list["results"][0]["login"]["password"])
+end
+puts "Done!"
+


### PR DESCRIPTION
Voilà pour le seeder. Il destroy la database à chaque fois que l'on fait rails db:seed et repeuple la database d'à peu près 100 users avec leur "email" et leur "url_avatar". On ne pourra pas accéder à ces user pour le sign in parce que les passwords (que l'on doit mettre obligatoirement pour créer des users) ne sont pas accessibles à part si on va les chercher 1 à 1 dans la API